### PR TITLE
add combination rule of diff

### DIFF
--- a/lib/formkeeper.rb
+++ b/lib/formkeeper.rb
@@ -323,6 +323,13 @@ module FormKeeper
       end
     end
 
+    class Different < Base
+      def validate(values, arg)
+        return false unless values.size == 2
+        values[0] != values[1]
+      end
+    end
+
     class Any < Base
       def validate(values, arg)
         values.any? { |v| not (v.nil? or v.empty?) }
@@ -726,6 +733,7 @@ module FormKeeper
     register_combination_constraint :date, CombinationConstraint::Date.new
     register_combination_constraint :time, CombinationConstraint::Time.new
     register_combination_constraint :same, CombinationConstraint::Same.new
+    register_combination_constraint :diff, CombinationConstraint::Different.new
     register_combination_constraint :any, CombinationConstraint::Any.new
 
     def initialize

--- a/lib/formkeeper/version.rb
+++ b/lib/formkeeper/version.rb
@@ -1,3 +1,3 @@
 module FormKeeper
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -250,7 +250,7 @@ describe FormKeeper::Validator do
     report.failed_on?(:colors)
   end
 
-  it "validates combination params" do
+  it "validates combination same params" do
 
     rule = FormKeeper::Rule.new
     rule.filters :strip
@@ -275,7 +275,7 @@ describe FormKeeper::Validator do
 
   end
 
-  it "validates combination params by synonym" do
+  it "validates combination same params by synonym" do
 
     rule = FormKeeper::Rule.new
     rule.filters :strip
@@ -300,7 +300,7 @@ describe FormKeeper::Validator do
 
   end
 
-  it "validates invalid combination params" do
+  it "validates invalid combination same params" do
 
     rule = FormKeeper::Rule.new
     rule.filters :strip
@@ -325,5 +325,74 @@ describe FormKeeper::Validator do
     report.failed_on?(:same_email_address).should eql(true)
 
   end
-end
 
+  it "validates combination diff params" do
+
+    rule = FormKeeper::Rule.new
+    rule.filters :strip
+    rule.field :old_password, :present => true, :length => 8..16
+    rule.field :new_password, :present => true, :length => 8..16
+    rule.combination :different_password, :fields => [:old_password, :new_password], :diff => true
+
+    params = {}
+    params['old_password'] = 'hogehogebar_old '
+    params['new_password'] = 'hogehogebar_new  '
+
+    validator = FormKeeper::Validator.new
+    report = validator.validate(params, rule)
+
+    #valid_params.keys.size.should == 2
+    report[:old_password].should == 'hogehogebar_old'
+    report[:new_password].should == 'hogehogebar_new'
+
+    report.failed?.should_not eql(true)
+
+  end
+
+  it "validates combination diff params by synonym" do
+
+    rule = FormKeeper::Rule.new
+    rule.filters :strip
+    rule.field :old_password, :present => true, :length => 8..16
+    rule.field :new_password, :present => true, :length => 8..16
+    rule.diff :different_password, [:old_password, :new_password], :filters => :upcase
+
+    params = {}
+    params['old_password'] = 'hogehogebar_old '
+    params['new_password'] = 'hogehogebar_new  '
+
+    validator = FormKeeper::Validator.new
+    report = validator.validate(params, rule)
+
+    #valid_params.keys.size.should == 2
+    report[:old_password].should == 'hogehogebar_old'
+    report[:new_password].should == 'hogehogebar_new'
+
+    report.failed?.should_not eql(true)
+
+  end
+
+  it "validates invalid combination diff params" do
+
+    rule = FormKeeper::Rule.new
+    rule.filters :strip
+    rule.field :old_password, :present => true, :length => 8..16
+    rule.field :new_password, :present => true, :length => 8..16
+    rule.diff :different_password, [:old_password, :new_password], :filters => :upcase
+
+    params = {}
+    params['old_password'] = 'hogehogebar_old '
+    params['new_password'] = 'hogehogebar_old  '
+
+    validator = FormKeeper::Validator.new
+    report = validator.validate(params, rule)
+
+    #valid_params.keys.size.should == 2
+    report[:old_password].should == 'hogehogebar_old'
+    report[:new_password].should == 'hogehogebar_old'
+
+    report.failed?.should eql(true)
+    report.failed_on?(:different_password).should eql(true)
+
+  end
+end


### PR DESCRIPTION
I have added one of combination rule `diff`
Most of my implements referenced existing rule `same`

I think that It will be used in case of some form.
For example, When we update registered data, we have to input both of  `old_password & new_password` or `old_email & new_email` and so on.
